### PR TITLE
Improve containerized builds with vanagon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Build gem
         uses: scarhand/actions-ruby@master
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,13 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7'
+        bundler: '2.4.22'
+        bundler-cache: true
     - name: Build and test with Rake
-      run: |
-        gem install bundler -v 2.4.22
-        bundle install --jobs 4 --retry 3
-        bundle exec rake
+      run: bundle exec rake

--- a/.github/workflows/ruby3.yml
+++ b/.github/workflows/ruby3.yml
@@ -11,7 +11,7 @@ jobs:
         ruby: [ '3.0', '3.1', '3.2']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby 3.x
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout repo content
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: setup ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,8 @@ require:
 - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.7
+  NewCops: enable
   Exclude:
   - "**/*.erb"
   - spec/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+- Bump minimum ruby requirement to 2.7
+- Fix preserve param default behaving like `always` but should be `on-failure`
 
 ## [0.53.0] - 2024-09-13
 ### Added

--- a/lib/vanagon/cli/build.rb
+++ b/lib/vanagon/cli/build.rb
@@ -15,10 +15,13 @@ class Vanagon
           -o, --only-build COMPONENT,COMPONENT,...
                                            Only build listed COMPONENTs
           -p, --preserve [RULE]            Rule for VM preservation: never, on-failure, always
-                                             [Default: always]
+                                             [Default: on-failure]
           -r, --remote-workdir DIRECTORY   Working directory on the remote host
           -s, --skipcheck                  Skip the "check" stage when building components
-          -w, --workdir DIRECTORY          Working directory on the local host
+          -w, --workdir DIRECTORY          Working directory on the local host,
+                                             managed automatically based on `keepwork` option
+          -k, --keepwork RULE              Rule for preserving local `workdir`: [Default: never]
+                                             always, on-success, on-failure, never
           -v, --verbose                    Only here for backwards compatibility. Does nothing.
 
         Engines:
@@ -66,12 +69,13 @@ class Vanagon
           '--engine' => :engine,
           '--skipcheck' => :skipcheck,
           '--preserve' => :preserve,
+          '--keepwork' => :keepwork,
           '--only-build' => :only_build,
           '<project-name>' => :project_name,
           '<platforms>' => :platforms,
           '<targets>' => :targets
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
 
       def options_validate(options)
@@ -81,6 +85,13 @@ class Vanagon
           raise InvalidArgument, "--preserve option can only be one of: #{valid_preserves.join(', ')}"
         end
         options[:preserve] = options[:preserve].to_sym
+
+        valid_keepwork = %w[always on-success on-failure never]
+        unless valid_keepwork.include? options[:keepwork]
+          raise InvalidArgument, "--keepwork option can only be one of: #{valid_keepwork.join(', ')}"
+        end
+        options[:keepwork] = options[:keepwork].to_sym
+
         return options
       end
     end

--- a/lib/vanagon/cli/build_host_info.rb
+++ b/lib/vanagon/cli/build_host_info.rb
@@ -51,7 +51,7 @@ class Vanagon
           '<platforms>' => :platforms,
           '<targets>' => :targets
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/build_requirements.rb
+++ b/lib/vanagon/cli/build_requirements.rb
@@ -39,9 +39,8 @@ class Vanagon
 
         components = driver.project.components
         component_names = components.map(&:name)
-        build_requirements = []
-        components.each do |component|
-          build_requirements << component.build_requires.reject do |requirement|
+        build_requirements = components.map do |component|
+          component.build_requires.reject do |requirement|
             # only include external requirements: i.e. those that do not match
             # other components in the project
             component_names.include?(requirement)
@@ -61,7 +60,7 @@ class Vanagon
           '<project-name>' => :project_name,
           '<platform>' => :platform,
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/completion.rb
+++ b/lib/vanagon/cli/completion.rb
@@ -37,7 +37,7 @@ class Vanagon
         translations = {
           '--shell' => :shell,
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/dependencies.rb
+++ b/lib/vanagon/cli/dependencies.rb
@@ -35,12 +35,10 @@ class Vanagon
 
         projects.each do |project|
           platforms.each do |platform|
-            begin
-              artifact = Vanagon::Driver.new(platform, project, options)
-              artifact.dependencies
-            rescue RuntimeError => e
-              failures.push("#{project}, #{platform}: #{e}")
-            end
+            artifact = Vanagon::Driver.new(platform, project, options)
+            artifact.dependencies
+          rescue RuntimeError => e
+            failures.push("#{project}, #{platform}: #{e}")
           end
         end
 
@@ -92,7 +90,7 @@ class Vanagon
           '<project-name>' => :project_name,
           '<platforms>' => :platforms
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/inspect.rb
+++ b/lib/vanagon/cli/inspect.rb
@@ -16,7 +16,10 @@ class Vanagon
 
           -p, --preserve [RULE]            Rule for VM preservation: never, on-failure, always
                                              [Default: on-failure]
-          -w, --workdir DIRECTORY          Working directory on the local host
+          -w, --workdir DIRECTORY          Working directory on the local host,
+                                             managed automatically based on `keepwork` option
+          -k, --keepwork RULE              Rule for preserving local `workdir`: [Default: never]
+                                             always, on-success, on-failure, never
           -v, --verbose                    Only here for backwards compatibility. Does nothing.
 
         Engines:
@@ -53,10 +56,11 @@ class Vanagon
           '--configdir' => :configdir,
           '--engine' => :engine,
           '--preserve' => :preserve,
+          '--keepwork' => :keepwork,
           '<project-name>' => :project_name,
           '<platforms>' => :platforms
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
 
       def options_validate(options)
@@ -66,6 +70,13 @@ class Vanagon
           raise InvalidArgument, "--preserve option can only be one of: #{valid_preserves.join(', ')}"
         end
         options[:preserve] = options[:preserve].to_sym
+
+        valid_keepwork = %w[always on-success on-failure never]
+        unless valid_keepwork.include? options[:keepwork]
+          raise InvalidArgument, "--keepwork option can only be one of: #{valid_keepwork.join(', ')}"
+        end
+        options[:keepwork] = options[:keepwork].to_sym
+
         return options
       end
     end

--- a/lib/vanagon/cli/list.rb
+++ b/lib/vanagon/cli/list.rb
@@ -87,7 +87,7 @@ class Vanagon
           '--projects' => :projects,
           '--use-spaces' => :use_spaces,
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/render.rb
+++ b/lib/vanagon/cli/render.rb
@@ -53,7 +53,7 @@ class Vanagon
           '<project-name>' => :project_name,
           '<platforms>' => :platforms,
         }
-        return docopt_options.map { |k, v| [translations[k], v] }.to_h
+        return docopt_options.transform_keys { |k| translations[k] }
       end
     end
   end

--- a/lib/vanagon/cli/ship.rb
+++ b/lib/vanagon/cli/ship.rb
@@ -22,7 +22,7 @@ class Vanagon
       def run(_)
         ENV['PROJECT_ROOT'] = Dir.pwd
 
-        if Dir['output/**/*'].select { |entry| File.file?(entry) }.empty?
+        if Dir['output/**/*'].none? { |entry| File.file?(entry) }
           VanagonLogger.error 'vanagon: Error: No packages to ship in the "output" directory. Maybe build some first?'
           exit 1
         end

--- a/lib/vanagon/cli/sign.rb
+++ b/lib/vanagon/cli/sign.rb
@@ -21,7 +21,7 @@ class Vanagon
 
       def run(_)
         ENV['PROJECT_ROOT'] = Dir.pwd
-        if Dir['output/**/*'].select { |entry| File.file?(entry) }.empty?
+        if Dir['output/**/*'].none? { |entry| File.file?(entry) }
           VanagonLogger.error 'sign: Error: No packages to sign in the "output" directory. Maybe build some first?'
           exit 1
         end

--- a/lib/vanagon/common/user.rb
+++ b/lib/vanagon/common/user.rb
@@ -15,10 +15,10 @@ class Vanagon
       #
       # @return [true, false] true if all attributes have equal values. false otherwise.
       def ==(other)
-        other.name == self.name && \
-          other.group == self.group && \
-          other.shell == self.shell && \
-          other.is_system == self.is_system && \
+        other.name == self.name &&
+          other.group == self.group &&
+          other.shell == self.shell &&
+          other.is_system == self.is_system &&
           other.homedir == self.homedir
       end
     end

--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -260,27 +260,25 @@ class Vanagon
     #   if #fetch is successful.
     def fetch_mirrors(options)
       mirrors.to_a.shuffle.each do |mirror|
-        begin
-          VanagonLogger.info %(Attempting to fetch from mirror URL "#{mirror}")
-          @source = Vanagon::Component::Source.source(mirror, **options)
-          return true if source.fetch
-        rescue Vanagon::InvalidSource
-          # This means that the URL was not a git repo or a valid downloadable file,
-          # which means either the URL is incorrect, or we don't have access to that
-          # resource. Return false, so that the pkg.url value can be used instead.
-          VanagonLogger.error %(Invalid source "#{mirror}")
-        rescue SocketError
-          # SocketError means that there was no DNS/name resolution
-          # for whatever remote protocol the mirror tried to use.
-          VanagonLogger.error %(Unable to resolve mirror URL "#{mirror}")
-        rescue StandardError
-          # Source retrieval does not consistently return a meaningful
-          # namespaced error message, which means we're brute-force rescuing
-          # StandardError. Also, we want to handle other unexpected things when
-          # we try reaching out to the URL, so that we can gracefully return
-          # false and fall back to fetching the pkg.url value instead.
-          VanagonLogger.error %(Unable to retrieve mirror URL "#{mirror}")
-        end
+        VanagonLogger.info %(Attempting to fetch from mirror URL "#{mirror}")
+        @source = Vanagon::Component::Source.source(mirror, **options)
+        return true if source.fetch
+      rescue Vanagon::InvalidSource
+        # This means that the URL was not a git repo or a valid downloadable file,
+        # which means either the URL is incorrect, or we don't have access to that
+        # resource. Return false, so that the pkg.url value can be used instead.
+        VanagonLogger.error %(Invalid source "#{mirror}")
+      rescue SocketError
+        # SocketError means that there was no DNS/name resolution
+        # for whatever remote protocol the mirror tried to use.
+        VanagonLogger.error %(Unable to resolve mirror URL "#{mirror}")
+      rescue StandardError
+        # Source retrieval does not consistently return a meaningful
+        # namespaced error message, which means we're brute-force rescuing
+        # StandardError. Also, we want to handle other unexpected things when
+        # we try reaching out to the URL, so that we can gracefully return
+        # false and fall back to fetching the pkg.url value instead.
+        VanagonLogger.error %(Unable to retrieve mirror URL "#{mirror}")
       end
       false
     end
@@ -317,10 +315,10 @@ class Vanagon
     def get_source(workdir) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
       opts = options.merge({ workdir: workdir, dirname: dirname })
       if url || !mirrors.empty?
-        if ENV['VANAGON_USE_MIRRORS'] == 'n' or ENV['VANAGON_USE_MIRRORS'] == 'false'
-          fetch_url(opts)
-        else
+        if %w[y yes true 1].include? ENV.fetch('VANAGON_USE_MIRRORS', 'n').downcase
           fetch_mirrors(opts) || fetch_url(opts)
+        else
+          fetch_url(opts)
         end
         source.verify
         extract_with << source.extract(platform.tar) if source.respond_to? :extract

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -39,7 +39,7 @@ class Vanagon
               #
               # Work around it by calling 'git ls-remote' directly ourselves.
               Timeout.timeout(timeout) do
-                Vanagon::Utilities.local_command("git ls-remote --heads #{url} > /dev/null 2>&1")
+                Vanagon::Utilities.local_command("git ls-remote --heads #{url} > /dev/null 2>&1", log: false)
                 $?.exitstatus.zero?
               end
             rescue RuntimeError
@@ -113,7 +113,12 @@ class Vanagon
         # and check out the ref. Also sets the version if there is a git tag as
         # a side effect.
         def fetch
-          clone!
+          begin
+            @clone ||= ::Git.open(File.join(workdir, dirname))
+            @clone.fetch
+          rescue ::Git::GitExecuteError, ArgumentError
+            clone!
+          end
           checkout!
           version
           update_submodules

--- a/lib/vanagon/logger.rb
+++ b/lib/vanagon/logger.rb
@@ -22,7 +22,7 @@ class VanagonLogger < Logger
   end
 
   def initialize(output = $stdout)
-    super(output)
+    super
     self.level = ::Logger::INFO
     self.formatter = proc do |severity, datetime, progname, msg|
       "#{msg}\n"

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -122,6 +122,8 @@ class Vanagon
     attr_accessor :docker_run_args
     attr_accessor :docker_run_command
     attr_accessor :use_docker_exec
+    attr_accessor :docker_arch
+    attr_accessor :docker_registry
 
     # AWS engine specific
     attr_accessor :aws_ami
@@ -258,6 +260,7 @@ class Vanagon
       @shasum ||= "sha1sum"
 
       @use_docker_exec = true
+      @docker_registry ||= 'docker.io'
 
       # Our first attempt at defining metadata about a platform
       @cross_compiled ||= false

--- a/lib/vanagon/platform.rb
+++ b/lib/vanagon/platform.rb
@@ -120,6 +120,7 @@ class Vanagon
     # Docker engine specific
     attr_accessor :docker_image
     attr_accessor :docker_run_args
+    attr_accessor :docker_run_command
     attr_accessor :use_docker_exec
 
     # AWS engine specific
@@ -256,7 +257,7 @@ class Vanagon
       @copy ||= "cp"
       @shasum ||= "sha1sum"
 
-      @use_docker_exec = false
+      @use_docker_exec = true
 
       # Our first attempt at defining metadata about a platform
       @cross_compiled ||= false

--- a/lib/vanagon/platform/deb.rb
+++ b/lib/vanagon/platform/deb.rb
@@ -144,7 +144,7 @@ class Vanagon
         @num_cores = "/usr/bin/nproc"
         @curl = "curl --silent --show-error --fail --location"
         @valid_operators = ['<', '>', '<=', '>=', '=', '<<', '>>']
-        super(name)
+        super
       end
     end
   end

--- a/lib/vanagon/platform/defaults/amazon-2-aarch64.rb
+++ b/lib/vanagon/platform/defaults/amazon-2-aarch64.rb
@@ -3,9 +3,26 @@ platform "amazon-2-aarch64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(autoconf automake createrepo gcc gcc-c++ rsync cmake3  make rpm-libs rpm-build libarchive)
+  packages = %w(
+    autoconf
+    automake
+    cmake3
+    createrepo
+    curl
+    gcc
+    gcc-c++
+    libtool
+    libarchive
+    make
+    rpm-libs
+    rpm-build
+    rsync
+    systemd
+    which
+  )
   plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "amazon-7-arm64"
   plat.docker_image "amazonlinux:2"
+  plat.docker_arch "linux/arm64"
 end

--- a/lib/vanagon/platform/defaults/amazon-2-aarch64.rb
+++ b/lib/vanagon/platform/defaults/amazon-2-aarch64.rb
@@ -7,4 +7,5 @@ platform "amazon-2-aarch64" do |plat|
   plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "amazon-7-arm64"
+  plat.docker_image "amazonlinux:2"
 end

--- a/lib/vanagon/platform/defaults/amazon-2023-aarch64.rb
+++ b/lib/vanagon/platform/defaults/amazon-2023-aarch64.rb
@@ -7,4 +7,5 @@ platform "amazon-2023-aarch64" do |plat|
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "amazon-2023-arm64"
+  plat.docker_image "amazonlinux:2023"
 end

--- a/lib/vanagon/platform/defaults/amazon-2023-aarch64.rb
+++ b/lib/vanagon/platform/defaults/amazon-2023-aarch64.rb
@@ -3,9 +3,26 @@ platform "amazon-2023-aarch64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(autoconf automake createrepo gcc gcc-c++ rsync cmake make rpm-libs rpm-build libarchive)
+  packages = %w(
+    autoconf
+    automake
+    cmake3
+    createrepo
+    curl
+    gcc
+    gcc-c++
+    libarchive
+    libtool
+    make
+    rpm-libs
+    rpm-build
+    rsync
+    systemd
+    which
+  )
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "amazon-2023-arm64"
   plat.docker_image "amazonlinux:2023"
+  plat.docker_arch "linux/arm64"
 end

--- a/lib/vanagon/platform/defaults/amazon-2023-x86_64.rb
+++ b/lib/vanagon/platform/defaults/amazon-2023-x86_64.rb
@@ -3,9 +3,26 @@ platform "amazon-2023-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(gcc gcc-c++ autoconf automake createrepo rsync cmake make rpm-libs rpm-build rpm-sign libtool libarchive)
+  packages = %w(
+    autoconf
+    automake
+    cmake3
+    createrepo
+    curl
+    gcc
+    gcc-c++
+    libarchive
+    libtool
+    make
+    rpm-libs
+    rpm-build
+    rsync
+    systemd
+    which
+  )
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "amazon-2023-x86_64"
   plat.docker_image "amazonlinux:2023"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/amazon-2023-x86_64.rb
+++ b/lib/vanagon/platform/defaults/amazon-2023-x86_64.rb
@@ -7,4 +7,5 @@ platform "amazon-2023-x86_64" do |plat|
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "amazon-2023-x86_64"
+  plat.docker_image "amazonlinux:2023"
 end

--- a/lib/vanagon/platform/defaults/amazon-7-aarch64.rb
+++ b/lib/vanagon/platform/defaults/amazon-7-aarch64.rb
@@ -7,4 +7,5 @@ platform "amazon-7-aarch64" do |plat|
   plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "amazon-7-arm64"
+  plat.docker_image "amazonlinux:2"
 end

--- a/lib/vanagon/platform/defaults/amazon-7-aarch64.rb
+++ b/lib/vanagon/platform/defaults/amazon-7-aarch64.rb
@@ -3,9 +3,26 @@ platform "amazon-7-aarch64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(autoconf automake createrepo gcc gcc-c++ rsync cmake3  make rpm-libs rpm-build libarchive)
+  packages = %w(
+    autoconf
+    automake
+    cmake3
+    createrepo
+    curl
+    gcc
+    gcc-c++
+    libarchive
+    libtool
+    make
+    rpm-libs
+    rpm-build
+    rsync
+    systemd
+    which
+  )
   plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "amazon-7-arm64"
   plat.docker_image "amazonlinux:2"
+  plat.docker_arch "linux/arm64"
 end

--- a/lib/vanagon/platform/defaults/debian-10-amd64.rb
+++ b/lib/vanagon/platform/defaults/debian-10-amd64.rb
@@ -4,9 +4,22 @@ platform "debian-10-amd64" do |plat|
   plat.servicetype "systemd"
   plat.codename "buster"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  packages = %w(
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    make
+    pkg-config
+    quilt
+    rsync
+    systemd
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-10-x86_64"
   plat.docker_image "debian:10"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/debian-10-amd64.rb
+++ b/lib/vanagon/platform/defaults/debian-10-amd64.rb
@@ -8,4 +8,5 @@ platform "debian-10-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-10-x86_64"
+  plat.docker_image "debian:10"
 end

--- a/lib/vanagon/platform/defaults/debian-11-aarch64.rb
+++ b/lib/vanagon/platform/defaults/debian-11-aarch64.rb
@@ -4,9 +4,25 @@ platform "debian-11-aarch64" do |plat|
   plat.servicetype "systemd"
   plat.codename "bullseye"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  # There's some weirdness in the latest docker image around libc-bin
+  plat.provision_with "mv /var/lib/dpkg/info/libc-bin.* /tmp/"
+  
+  packages = %w(
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    make
+    pkg-config
+    quilt
+    rsync
+    systemd
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-11-arm64"
   plat.docker_image "debian:11"
+  plat.docker_arch "linux/arm64"
 end

--- a/lib/vanagon/platform/defaults/debian-11-aarch64.rb
+++ b/lib/vanagon/platform/defaults/debian-11-aarch64.rb
@@ -8,4 +8,5 @@ platform "debian-11-aarch64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-11-arm64"
+  plat.docker_image "debian:11"
 end

--- a/lib/vanagon/platform/defaults/debian-11-amd64.rb
+++ b/lib/vanagon/platform/defaults/debian-11-amd64.rb
@@ -4,9 +4,22 @@ platform "debian-11-amd64" do |plat|
   plat.servicetype "systemd"
   plat.codename "bullseye"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  packages = %w(
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    make
+    pkg-config
+    quilt
+    rsync
+    systemd
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-11-x86_64"
   plat.docker_image "debian:11"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/debian-11-amd64.rb
+++ b/lib/vanagon/platform/defaults/debian-11-amd64.rb
@@ -8,4 +8,5 @@ platform "debian-11-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-11-x86_64"
+  plat.docker_image "debian:11"
 end

--- a/lib/vanagon/platform/defaults/debian-12-aarch64.rb
+++ b/lib/vanagon/platform/defaults/debian-12-aarch64.rb
@@ -4,9 +4,22 @@ platform "debian-12-aarch64" do |plat|
   plat.servicetype "systemd"
   plat.codename "bookworm"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  packages = %w(
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    make
+    pkg-config
+    quilt
+    rsync
+    systemd
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-12-arm64"
   plat.docker_image "debian:12"
+  plat.docker_arch "linux/arm64"
 end

--- a/lib/vanagon/platform/defaults/debian-12-aarch64.rb
+++ b/lib/vanagon/platform/defaults/debian-12-aarch64.rb
@@ -8,4 +8,5 @@ platform "debian-12-aarch64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-12-arm64"
+  plat.docker_image "debian:12"
 end

--- a/lib/vanagon/platform/defaults/debian-12-amd64.rb
+++ b/lib/vanagon/platform/defaults/debian-12-amd64.rb
@@ -4,9 +4,22 @@ platform "debian-12-amd64" do |plat|
   plat.servicetype "systemd"
   plat.codename "bookworm"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  packages = %w(
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    make
+    pkg-config
+    quilt
+    rsync
+    systemd
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-12-x86_64"
   plat.docker_image "debian:12"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/debian-12-amd64.rb
+++ b/lib/vanagon/platform/defaults/debian-12-amd64.rb
@@ -8,4 +8,5 @@ platform "debian-12-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-12-x86_64"
+  plat.docker_image "debian:12"
 end

--- a/lib/vanagon/platform/defaults/debian-8-amd64.rb
+++ b/lib/vanagon/platform/defaults/debian-8-amd64.rb
@@ -10,4 +10,5 @@ platform "debian-8-amd64" do |plat|
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-8-x86_64"
   plat.docker_image "debian:8.11"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/debian-8-amd64.rb
+++ b/lib/vanagon/platform/defaults/debian-8-amd64.rb
@@ -9,4 +9,5 @@ platform "debian-8-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-8-x86_64"
+  plat.docker_image "debian:8.11"
 end

--- a/lib/vanagon/platform/defaults/debian-8-i386.rb
+++ b/lib/vanagon/platform/defaults/debian-8-i386.rb
@@ -9,4 +9,5 @@ platform "debian-8-i386" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends"
   plat.vmpooler_template "debian-8-i386"
+  plat.docker_image "debian:8.11"
 end

--- a/lib/vanagon/platform/defaults/el-7-x86_64.rb
+++ b/lib/vanagon/platform/defaults/el-7-x86_64.rb
@@ -3,9 +3,30 @@ platform "el-7-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
-  packages = %w(autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign)
+  plat.add_build_repository "https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
+  packages = %w(
+    autoconf
+    automake
+    cmake
+    cmake3
+    createrepo
+    curl
+    gcc
+    make
+    oracle-softwarecollection-release-el7
+    rpmdevtools
+    rpm-libs
+    rpm-sign
+    rsync
+    systemd
+    yum-utils
+    which
+  )
   plat.provision_with "yum install --assumeyes #{packages.join(' ')}"
+  plat.provision_with "yum install --assumeyes devtoolset-7-gcc devtoolset-7-gcc-c++"
+  plat.provision_with "scl enable devtoolset-7 bash"
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "redhat-7-x86_64"
+  plat.docker_image "oraclelinux:7"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/el-8-aarch64.rb
+++ b/lib/vanagon/platform/defaults/el-8-aarch64.rb
@@ -7,4 +7,5 @@ platform "el-8-aarch64" do |plat|
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-8-arm64"
+  plat.docker_image "redhat/ubi8:latest"
 end

--- a/lib/vanagon/platform/defaults/el-8-aarch64.rb
+++ b/lib/vanagon/platform/defaults/el-8-aarch64.rb
@@ -3,9 +3,25 @@ platform "el-8-aarch64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(autoconf automake createrepo gcc gcc-c++ rsync cmake make rpm-libs rpm-build libarchive)
+  packages = %w(
+    autoconf
+    automake
+    cmake
+    createrepo
+    gcc
+    gcc-c++
+    libarchive
+    libtool
+    make
+    rpm-build
+    rpm-libs
+    rsync
+    systemd
+    which
+  )
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-8-arm64"
-  plat.docker_image "redhat/ubi8:latest"
+  plat.docker_image "almalinux:8"
+  plat.docker_arch "linux/arm64"
 end

--- a/lib/vanagon/platform/defaults/el-8-ppc64le.rb
+++ b/lib/vanagon/platform/defaults/el-8-ppc64le.rb
@@ -3,13 +3,13 @@ platform 'el-8-ppc64le' do |plat|
   plat.defaultdir '/etc/sysconfig'
   plat.servicetype 'systemd'
 
-  # Workaround for an issue with RedHat subscription metadata, see ITSYS-2543
-  plat.provision_with('subscription-manager repos --disable rhel-8-for-ppc64le-baseos-rpms && subscription-manager repos --enable rhel-8-for-ppc64le-baseos-rpms')
-
   packages = %w(
     autoconf
     automake
     cmake
+    createrepo
+    curl
+    gcc
     gcc-c++
     java-1.8.0-openjdk-devel
     libarchive
@@ -18,13 +18,19 @@ platform 'el-8-ppc64le' do |plat|
     patch
     perl-Getopt-Long
     readline-devel
+    rpm-build
+    rpm-libs
+    rsync
     swig
+    systemd
     systemtap-sdt-devel
+    which
     zlib-devel
   )
 
   plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
   plat.install_build_dependencies_with 'dnf install -y --allowerasing'
   plat.vmpooler_template 'redhat-8-power8'
-  plat.docker_image "redhat/ubi8:latest"
+  plat.docker_image "almalinux:8"
+  plat.docker_arch "linux/ppc64le"
 end

--- a/lib/vanagon/platform/defaults/el-8-ppc64le.rb
+++ b/lib/vanagon/platform/defaults/el-8-ppc64le.rb
@@ -26,4 +26,5 @@ platform 'el-8-ppc64le' do |plat|
   plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
   plat.install_build_dependencies_with 'dnf install -y --allowerasing'
   plat.vmpooler_template 'redhat-8-power8'
+  plat.docker_image "redhat/ubi8:latest"
 end

--- a/lib/vanagon/platform/defaults/el-8-x86_64.rb
+++ b/lib/vanagon/platform/defaults/el-8-x86_64.rb
@@ -7,4 +7,5 @@ platform "el-8-x86_64" do |plat|
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-8-x86_64"
+  plat.docker_image "redhat/ubi8:latest"
 end

--- a/lib/vanagon/platform/defaults/el-8-x86_64.rb
+++ b/lib/vanagon/platform/defaults/el-8-x86_64.rb
@@ -3,9 +3,26 @@ platform "el-8-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(gcc gcc-c++ autoconf automake createrepo rsync cmake make rpm-libs rpm-build rpm-sign libtool libarchive)
+  packages = %w(
+    autoconf
+    automake
+    cmake
+    createrepo
+    curl
+    gcc
+    gcc-c++
+    libarchive
+    libtool
+    make
+    rpm-build
+    rpm-libs
+    rsync
+    systemd
+    which
+  )
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-8-x86_64"
-  plat.docker_image "redhat/ubi8:latest"
+  plat.docker_image "almalinux:8"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/el-9-aarch64.rb
+++ b/lib/vanagon/platform/defaults/el-9-aarch64.rb
@@ -3,9 +3,27 @@ platform "el-9-aarch64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(autoconf automake createrepo gcc gcc-c++ rsync cmake make rpm-libs rpm-build libarchive)
-  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
+  packages = %w(
+    autoconf
+    automake
+    cmake
+    createrepo
+    curl
+    dnf-utils
+    gcc
+    gcc-c++
+    libarchive
+    libtool
+    make
+    rpm-build
+    rpm-libs
+    rsync
+    systemd
+    which
+  )
+  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')} && dnf config-manager --set-enabled crb"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-9-arm64"
-  plat.docker_image "redhat/ubi9:latest"
+  plat.docker_image "almalinux:9"
+  plat.docker_arch "linux/arm64"
 end

--- a/lib/vanagon/platform/defaults/el-9-aarch64.rb
+++ b/lib/vanagon/platform/defaults/el-9-aarch64.rb
@@ -7,4 +7,5 @@ platform "el-9-aarch64" do |plat|
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-9-arm64"
+  plat.docker_image "redhat/ubi9:latest"
 end

--- a/lib/vanagon/platform/defaults/el-9-ppc64le.rb
+++ b/lib/vanagon/platform/defaults/el-9-ppc64le.rb
@@ -3,28 +3,35 @@ platform 'el-9-ppc64le' do |plat|
   plat.defaultdir '/etc/sysconfig'
   plat.servicetype 'systemd'
 
-  # Workaround for an issue with RedHat subscription metadata, see ITSYS-2543
-  plat.provision_with('subscription-manager repos --disable rhel-9-for-ppc64le-baseos-rpms && subscription-manager repos --enable rhel-9-for-ppc64le-baseos-rpms --enable codeready-builder-for-rhel-9-ppc64le-rpms')
-
   packages = %w(
     autoconf
     automake
     cmake
+    createrepo
+    curl
+    dnf-utils
+    gcc
     gcc-c++
     java-1.8.0-openjdk-devel
     libarchive
+    libtool
     libselinux-devel
     make
     patch
     perl-Getopt-Long
     readline-devel
-    swig
+    rpm-libs
+    rpm-build
+    rsync
+    systemd
     systemtap-sdt-devel
+    which
     zlib-devel
   )
 
-  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
+  plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')} && dnf config-manager --set-enabled crb")
   plat.install_build_dependencies_with 'dnf install -y --allowerasing'
   plat.vmpooler_template 'redhat-9-power9'
-  plat.docker_image "redhat/ubi9:latest"
+  plat.docker_image "almalinux:9"
+  plat.docker_arch "linux/ppc64le"
 end

--- a/lib/vanagon/platform/defaults/el-9-ppc64le.rb
+++ b/lib/vanagon/platform/defaults/el-9-ppc64le.rb
@@ -26,4 +26,5 @@ platform 'el-9-ppc64le' do |plat|
   plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
   plat.install_build_dependencies_with 'dnf install -y --allowerasing'
   plat.vmpooler_template 'redhat-9-power9'
+  plat.docker_image "redhat/ubi9:latest"
 end

--- a/lib/vanagon/platform/defaults/el-9-x86_64.rb
+++ b/lib/vanagon/platform/defaults/el-9-x86_64.rb
@@ -3,9 +3,27 @@ platform "el-9-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(gcc gcc-c++ autoconf automake createrepo rsync cmake make rpm-libs rpm-build rpm-sign libtool libarchive)
-  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
+  packages = %w(
+    autoconf
+    automake
+    cmake
+    createrepo
+    curl
+    dnf-utils
+    gcc
+    gcc-c++
+    libarchive
+    libtool
+    make
+    rpm-build
+    rpm-libs
+    rsync
+    systemd
+    which
+  )
+  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')} && dnf config-manager --set-enabled crb"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-9-x86_64"
-  plat.docker_image "redhat/ubi9:latest"
+  plat.docker_image "almalinux:9"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/el-9-x86_64.rb
+++ b/lib/vanagon/platform/defaults/el-9-x86_64.rb
@@ -7,4 +7,5 @@ platform "el-9-x86_64" do |plat|
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-9-x86_64"
+  plat.docker_image "redhat/ubi9:latest"
 end

--- a/lib/vanagon/platform/defaults/fedora-36-x86_64.rb
+++ b/lib/vanagon/platform/defaults/fedora-36-x86_64.rb
@@ -4,14 +4,35 @@ platform 'fedora-36-x86_64' do |plat|
   plat.servicetype 'systemd'
   plat.dist 'fc36'
 
-  packages = %w[
-    autoconf automake bzip2-devel gcc gcc-c++ libselinux-devel
-    libsepol libsepol-devel make cmake pkgconfig readline-devel
-    rpmdevtools rsync swig zlib-devel systemtap-sdt-devel
-    perl-lib perl-FindBin
-  ]
+  packages = %w(
+    autoconf
+    automake
+    binutils
+    bzip2-devel
+    cmake
+    curl
+    gcc
+    gcc-c++
+    libselinux-devel
+    libsepol
+    libsepol-devel
+    make
+    perl-lib
+    perl-FindBin
+    pkgconfig
+    readline-devel
+    rpmdevtools
+    rsync
+    swig
+    systemtap-sdt-devel
+    systemd
+    which
+    zlib-devel
+  )
   plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
 
   plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
   plat.vmpooler_template 'fedora-36-x86_64'
+  plat.docker_image 'fedora:36'
+  plat.docker_arch 'linux/amd64'
 end

--- a/lib/vanagon/platform/defaults/fedora-38-x86_64.rb
+++ b/lib/vanagon/platform/defaults/fedora-38-x86_64.rb
@@ -14,4 +14,5 @@ platform 'fedora-38-x86_64' do |plat|
 
   plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
   plat.vmpooler_template 'fedora-38-x86_64'
+  plat.docker_image "fedora:38"
 end

--- a/lib/vanagon/platform/defaults/fedora-38-x86_64.rb
+++ b/lib/vanagon/platform/defaults/fedora-38-x86_64.rb
@@ -4,15 +4,35 @@ platform 'fedora-38-x86_64' do |plat|
   plat.servicetype 'systemd'
   plat.dist 'fc38'
 
-  packages = %w[
-    autoconf automake bzip2-devel gcc gcc-c++ libselinux-devel
-    libsepol libsepol-devel make cmake pkgconfig readline-devel
-    rpmdevtools rsync swig zlib-devel systemtap-sdt-devel
-    perl-lib perl-FindBin
-  ]
+  packages = %w(
+    autoconf
+    automake
+    binutils
+    bzip2-devel
+    cmake
+    curl
+    gcc
+    gcc-c++
+    libselinux-devel
+    libsepol
+    libsepol-devel
+    make
+    perl-lib
+    perl-FindBin
+    pkgconfig
+    readline-devel
+    rpmdevtools
+    rsync
+    swig
+    systemtap-sdt-devel
+    systemd
+    which
+    zlib-devel
+  )
   plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
 
   plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
   plat.vmpooler_template 'fedora-38-x86_64'
   plat.docker_image "fedora:38"
+  plat.docker_arch 'linux/amd64'
 end

--- a/lib/vanagon/platform/defaults/fedora-40-x86_64.rb
+++ b/lib/vanagon/platform/defaults/fedora-40-x86_64.rb
@@ -4,15 +4,35 @@ platform 'fedora-40-x86_64' do |plat|
   plat.servicetype 'systemd'
   plat.dist 'fc40'
 
-  packages = %w[
-    autoconf automake bzip2-devel gcc gcc-c++ libselinux-devel
-    libsepol libsepol-devel make cmake pkgconfig readline-devel
-    rpmdevtools rsync swig zlib-devel systemtap-sdt-devel
-    perl-lib perl-FindBin
-  ]
+  packages = %w(
+    autoconf
+    automake
+    binutils
+    bzip2-devel
+    cmake
+    curl
+    gcc
+    gcc-c++
+    libselinux-devel
+    libsepol
+    libsepol-devel
+    make
+    perl-lib
+    perl-FindBin
+    pkgconfig
+    readline-devel
+    rpmdevtools
+    rsync
+    swig
+    systemtap-sdt-devel
+    systemd
+    which
+    zlib-devel
+  )
   plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
 
   plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
   plat.vmpooler_template 'fedora-40-x86_64'
   plat.docker_image "fedora:40"
+  plat.docker_arch 'linux/amd64'
 end

--- a/lib/vanagon/platform/defaults/fedora-40-x86_64.rb
+++ b/lib/vanagon/platform/defaults/fedora-40-x86_64.rb
@@ -14,4 +14,5 @@ platform 'fedora-40-x86_64' do |plat|
 
   plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
   plat.vmpooler_template 'fedora-40-x86_64'
+  plat.docker_image "fedora:40"
 end

--- a/lib/vanagon/platform/defaults/sles-12-x86_64.rb
+++ b/lib/vanagon/platform/defaults/sles-12-x86_64.rb
@@ -3,9 +3,13 @@ platform "sles-12-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
+  #plat.provision_with 'zypper addrepo "https://download.suse.com/Download?build=0&package=sles12-sp5&url=https://download.suse.com/Download/repo/SUSE/Products/SLE-Product-SLE-12-SP5-Desktop/x86_64/" SLES12-SP5-Updates'
+  #plat.provision_with 'zypper addrepo "https://download.suse.com/Download?build=0&package=sles12-sp5&url=https://download.suse.com/Download/repo/SUSE/Updates/SLE-12-SP5/x86_64/" SLES12-SP5-Pool'
   packages = %w(aaa_base autoconf automake rsync gcc make rpm-build)
   plat.provision_with "zypper -n --no-gpg-checks install -y #{packages.join(' ')}"
   plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
   plat.vmpooler_template "sles-12-x86_64"
+  plat.docker_registry "registry.suse.com/suse"
+  plat.docker_image "sles12sp5:latest"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/sles-15-x86_64.rb
+++ b/lib/vanagon/platform/defaults/sles-15-x86_64.rb
@@ -3,8 +3,25 @@ platform "sles-15-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(aaa_base autoconf automake rsync gcc gcc-c++ make rpm-build gettext-tools cmake)
+  packages = %w(
+    aaa_base
+    autoconf
+    automake
+    cmake
+    curl
+    gcc
+    gcc-c++
+    gettext-tools
+    make
+    rpm-build
+    rsync
+    systemd
+    which
+  )
   plat.provision_with "zypper -n --no-gpg-checks install -y #{packages.join(' ')}"
   plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
   plat.vmpooler_template "sles-15-x86_64"
+  plat.docker_registry "registry.suse.com/suse"
+  plat.docker_image "sle15:15.6"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-18.04-aarch64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-18.04-aarch64.rb
@@ -25,4 +25,5 @@ platform "ubuntu-18.04-aarch64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1804-arm64"
+  plat.docker_image "ubuntu:18.04"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-18.04-aarch64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-18.04-aarch64.rb
@@ -8,6 +8,7 @@ platform "ubuntu-18.04-aarch64" do |plat|
     autoconf
     build-essential
     cmake
+    curl
     debhelper
     devscripts
     fakeroot
@@ -19,6 +20,7 @@ platform "ubuntu-18.04-aarch64" do |plat|
     quilt
     rsync
     swig
+    systemd
     systemtap-sdt-dev
     zlib1g-dev
   )
@@ -26,4 +28,5 @@ platform "ubuntu-18.04-aarch64" do |plat|
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1804-arm64"
   plat.docker_image "ubuntu:18.04"
+  plat.docker_arch "linux/arm64"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-18.04-amd64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-18.04-amd64.rb
@@ -4,10 +4,29 @@ platform "ubuntu-18.04-amd64" do |plat|
   plat.servicetype "systemd"
   plat.codename "bionic"
 
-  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot)
+  packages = %w(
+    autoconf
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    libbz2-dev
+    libreadline-dev
+    libselinux1-dev
+    openjdk-8-jre-headless
+    pkg-config
+    quilt
+    rsync
+    swig
+    systemd
+    systemtap-sdt-dev
+    zlib1g-dev
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "export DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1804-x86_64"
   plat.docker_image "ubuntu:18.04"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-18.04-amd64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-18.04-amd64.rb
@@ -9,4 +9,5 @@ platform "ubuntu-18.04-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "export DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1804-x86_64"
+  plat.docker_image "ubuntu:18.04"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-20.04-aarch64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-20.04-aarch64.rb
@@ -8,4 +8,5 @@ platform "ubuntu-20.04-aarch64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2004-arm64"
+  plat.docker_image "ubuntu:20.04"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-20.04-aarch64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-20.04-aarch64.rb
@@ -4,9 +4,29 @@ platform "ubuntu-20.04-aarch64" do |plat|
   plat.servicetype "systemd"
   plat.codename "focal"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  packages = %w(
+    autoconf
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    libbz2-dev
+    libreadline-dev
+    libselinux1-dev
+    openjdk-8-jre-headless
+    pkg-config
+    quilt
+    rsync
+    swig
+    systemd
+    systemtap-sdt-dev
+    zlib1g-dev
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2004-arm64"
   plat.docker_image "ubuntu:20.04"
+  plat.docker_arch "linux/arm64"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-20.04-amd64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-20.04-amd64.rb
@@ -3,18 +3,31 @@ platform "ubuntu-20.04-amd64" do |plat|
   plat.defaultdir "/etc/default"
   plat.servicetype "systemd"
   plat.codename "focal"
-
-  if %w[y yes true].include? ENV.fetch('VANAGON_USE_MIRRORS', 'y').downcase
-    # Temporary fix to add focal-updates.list repo file because it is missing from the vmpooler image
-    plat.provision_with "echo 'deb https://artifactory.delivery.puppetlabs.net/artifactory/ubuntu__remote focal-updates main restricted universe multiverse' > /etc/apt/sources.list.d/focal-updates.list;
-    echo 'deb-src https://artifactory.delivery.puppetlabs.net/artifactory/ubuntu__remote focal-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/focal-updates.list"
-  end
   
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
-
+  packages = %w(
+    autoconf
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    libbz2-dev
+    libreadline-dev
+    libselinux1-dev
+    openjdk-8-jre-headless
+    pkg-config
+    quilt
+    rsync
+    swig
+    systemd
+    systemtap-sdt-dev
+    zlib1g-dev
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
-  plat.provision_with "curl https://apt.puppet.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -"
+  #plat.provision_with "curl https://apt.puppet.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2004-x86_64"
   plat.docker_image "ubuntu:20.04"
+  plat.docker_arch 'linux/amd64'
 end

--- a/lib/vanagon/platform/defaults/ubuntu-20.04-amd64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-20.04-amd64.rb
@@ -4,9 +4,11 @@ platform "ubuntu-20.04-amd64" do |plat|
   plat.servicetype "systemd"
   plat.codename "focal"
 
-  # Temporary fix to add focal-updates.list repo file because it is missing from the vmpooler image
-  plat.provision_with "echo 'deb https://artifactory.delivery.puppetlabs.net/artifactory/ubuntu__remote focal-updates main restricted universe multiverse' > /etc/apt/sources.list.d/focal-updates.list;
-  echo 'deb-src https://artifactory.delivery.puppetlabs.net/artifactory/ubuntu__remote focal-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/focal-updates.list"
+  if %w[y yes true].include? ENV.fetch('VANAGON_USE_MIRRORS', 'y').downcase
+    # Temporary fix to add focal-updates.list repo file because it is missing from the vmpooler image
+    plat.provision_with "echo 'deb https://artifactory.delivery.puppetlabs.net/artifactory/ubuntu__remote focal-updates main restricted universe multiverse' > /etc/apt/sources.list.d/focal-updates.list;
+    echo 'deb-src https://artifactory.delivery.puppetlabs.net/artifactory/ubuntu__remote focal-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/focal-updates.list"
+  end
   
   packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
 
@@ -14,4 +16,5 @@ platform "ubuntu-20.04-amd64" do |plat|
   plat.provision_with "curl https://apt.puppet.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2004-x86_64"
+  plat.docker_image "ubuntu:20.04"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-22.04-aarch64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-22.04-aarch64.rb
@@ -4,9 +4,32 @@ platform "ubuntu-22.04-aarch64" do |plat|
   plat.servicetype "systemd"
   plat.codename "jammy"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  # There's some weirdness in the latest ubuntu 22 docker image around libc-bin
+  plat.provision_with "mv /var/lib/dpkg/info/libc-bin.* /tmp/"
+  
+  packages = %w(
+    autoconf
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    libbz2-dev
+    libreadline-dev
+    libselinux1-dev
+    openjdk-8-jre-headless
+    pkg-config
+    quilt
+    rsync
+    swig
+    systemd
+    systemtap-sdt-dev
+    zlib1g-dev
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2204-arm64"
   plat.docker_image "ubuntu:22.04"
+  plat.docker_arch 'linux/arm64'
 end

--- a/lib/vanagon/platform/defaults/ubuntu-22.04-aarch64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-22.04-aarch64.rb
@@ -8,4 +8,5 @@ platform "ubuntu-22.04-aarch64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2204-arm64"
+  plat.docker_image "ubuntu:22.04"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-22.04-amd64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-22.04-amd64.rb
@@ -9,4 +9,5 @@ platform "ubuntu-22.04-amd64" do |plat|
   plat.provision_with "curl https://apt.puppet.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2204-x86_64"
+  plat.docker_image "ubuntu:22.04"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-22.04-amd64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-22.04-amd64.rb
@@ -4,10 +4,30 @@ platform "ubuntu-22.04-amd64" do |plat|
   plat.servicetype "systemd"
   plat.codename "jammy"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  packages = %w(
+    autoconf
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    libbz2-dev
+    libreadline-dev
+    libselinux1-dev
+    openjdk-8-jre-headless
+    pkg-config
+    quilt
+    rsync
+    swig
+    systemd
+    systemtap-sdt-dev
+    zlib1g-dev
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
-  plat.provision_with "curl https://apt.puppet.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -"
+  #plat.provision_with "curl https://apt.puppet.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2204-x86_64"
   plat.docker_image "ubuntu:22.04"
+  plat.docker_arch 'linux/amd64'
 end

--- a/lib/vanagon/platform/defaults/ubuntu-24.04-aarch64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-24.04-aarch64.rb
@@ -4,9 +4,29 @@ platform "ubuntu-24.04-aarch64" do |plat|
   plat.servicetype "systemd"
   plat.codename "noble"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  packages = %w(
+    autoconf
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    libbz2-dev
+    libreadline-dev
+    libselinux1-dev
+    openjdk-8-jre-headless
+    pkg-config
+    quilt
+    rsync
+    swig
+    systemd
+    systemtap-sdt-dev
+    zlib1g-dev
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2404-arm64"
   plat.docker_image "ubuntu:24.04"
+  plat.docker_arch 'linux/arm64'
 end

--- a/lib/vanagon/platform/defaults/ubuntu-24.04-aarch64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-24.04-aarch64.rb
@@ -8,4 +8,5 @@ platform "ubuntu-24.04-aarch64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2404-arm64"
+  plat.docker_image "ubuntu:24.04"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-24.04-amd64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-24.04-amd64.rb
@@ -9,4 +9,5 @@ platform "ubuntu-24.04-amd64" do |plat|
   plat.provision_with "curl https://apt.puppet.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2404-x86_64"
+  plat.docker_image "ubuntu:24.04"
 end

--- a/lib/vanagon/platform/defaults/ubuntu-24.04-amd64.rb
+++ b/lib/vanagon/platform/defaults/ubuntu-24.04-amd64.rb
@@ -4,10 +4,30 @@ platform "ubuntu-24.04-amd64" do |plat|
   plat.servicetype "systemd"
   plat.codename "noble"
 
-  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake curl)
+  packages = %w(
+    autoconf
+    build-essential
+    cmake
+    curl
+    debhelper
+    devscripts
+    fakeroot
+    libbz2-dev
+    libreadline-dev
+    libselinux1-dev
+    openjdk-8-jre-headless
+    pkg-config
+    quilt
+    rsync
+    swig
+    systemd
+    systemtap-sdt-dev
+    zlib1g-dev
+  )
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
-  plat.provision_with "curl https://apt.puppet.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -"
+  #plat.provision_with "curl https://apt.puppet.com/DEB-GPG-KEY-puppet-20250406 | apt-key add -"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-2404-x86_64"
   plat.docker_image "ubuntu:24.04"
+  plat.docker_arch 'linux/amd64'
 end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -247,7 +247,7 @@ class Vanagon
         @platform.servicedir = dir
 
         # Add to the servicetypes array if we haven't already
-        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.select { |s| s.servicetype == @platform.servicetype }.empty?
+        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.none? { |s| s.servicetype == @platform.servicetype }
           @platform.servicetypes << OpenStruct.new(:servicetype => @platform.servicetype, :servicedir => @platform.servicedir)
         end
       end
@@ -263,7 +263,7 @@ class Vanagon
       #
       # @param type [String] service type for the platform ('sysv' for example)
       # @param servicedir [String] service dir for this platform and service type ('/etc/init.d' for example). Optional.
-      def servicetype(type, servicedir: nil) # rubocop:disable Metrics/AbcSize
+      def servicetype(type, servicedir: nil)
         if servicedir
           @platform.servicetypes << OpenStruct.new(:servicetype => type, :servicedir => servicedir)
         else
@@ -271,7 +271,7 @@ class Vanagon
         end
 
         # Add to the servicetypes array if we haven't already
-        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.select { |s| s.servicetype == @platform.servicetype }.empty?
+        if @platform.servicetype && @platform.servicedir && @platform.servicetypes.none? { |s| s.servicetype == @platform.servicetype }
           @platform.servicetypes << OpenStruct.new(:servicetype => @platform.servicetype, :servicedir => @platform.servicedir)
         end
       end

--- a/lib/vanagon/platform/dsl.rb
+++ b/lib/vanagon/platform/dsl.rb
@@ -319,6 +319,14 @@ class Vanagon
         @platform.docker_image = image_name
       end
 
+      def docker_arch(arch_name)
+        @platform.docker_arch = arch_name
+      end
+
+      def docker_registry(registry)
+        @platform.docker_registry = registry
+      end
+
       # Set additional `docker run` arguments to pass when creating containers
       #
       # @param args [Array<String>] array of CLI arguments for `docker run`

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -136,7 +136,7 @@ class Vanagon
         @num_cores = "/usr/sbin/sysctl -n hw.physicalcpu"
         @mktemp = "mktemp -d -t 'tmp'"
         @brew = '/usr/local/bin/brew'
-        super(name)
+        super
       end
     end
   end

--- a/lib/vanagon/platform/rpm.rb
+++ b/lib/vanagon/platform/rpm.rb
@@ -104,7 +104,7 @@ class Vanagon
         @num_cores ||= "/bin/grep -c 'processor' /proc/cpuinfo"
         @rpmbuild ||= "/usr/bin/rpmbuild"
         @curl = "curl --silent --show-error --fail --location"
-        super(name)
+        super
       end
     end
   end

--- a/lib/vanagon/platform/rpm/aix.rb
+++ b/lib/vanagon/platform/rpm/aix.rb
@@ -22,7 +22,7 @@ class Vanagon
           @num_cores = "lsdev -Cc processor |wc -l"
           @install = "/opt/freeware/bin/install"
           @rpmbuild = "/usr/bin/rpm"
-          super(name)
+          super
         end
       end
     end

--- a/lib/vanagon/platform/rpm/eos.rb
+++ b/lib/vanagon/platform/rpm/eos.rb
@@ -14,7 +14,7 @@ class Vanagon
           else
             case project.platform.package_type
             when "rpm"
-              return super(project)
+              return super
             when "swix"
               return generate_swix_package(project)
             else
@@ -34,7 +34,7 @@ class Vanagon
           else
             case project.platform.package_type
             when "rpm"
-              return super(project)
+              return super
             when "swix"
               return swix_package_name(project)
             else

--- a/lib/vanagon/platform/solaris_10.rb
+++ b/lib/vanagon/platform/solaris_10.rb
@@ -189,7 +189,7 @@ class Vanagon
         @shasum = "/opt/csw/bin/shasum"
         # solaris 10
         @num_cores = "/usr/bin/kstat cpu_info | awk '{print $$1}' | grep '^core_id$$' | wc -l"
-        super(name)
+        super
         if @architecture == "sparc"
           @platform_triple = "sparc-sun-solaris2.#{@os_version}"
         elsif @architecture == "i386"

--- a/lib/vanagon/platform/solaris_11.rb
+++ b/lib/vanagon/platform/solaris_11.rb
@@ -118,7 +118,7 @@ class Vanagon
         @patch = "/usr/bin/gpatch"
         @sed = "/usr/gnu/bin/sed"
         @num_cores = "/usr/bin/kstat cpu_info | /usr/bin/ggrep -E '[[:space:]]+core_id[[:space:]]' | wc -l"
-        super(name)
+        super
         if @architecture == "sparc"
           @platform_triple = "sparc-sun-solaris2.#{@os_version}"
         elsif @architecture == "i386"

--- a/lib/vanagon/platform/windows.rb
+++ b/lib/vanagon/platform/windows.rb
@@ -457,7 +457,7 @@ class Vanagon
         @install = "/usr/bin/install"
         @copy = "/usr/bin/cp"
         @package_type = "msi"
-        super(name)
+        super
       end
     end
   end

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -462,13 +462,8 @@ class Vanagon
     # @return [Array] of OpenStructs of all interest triggers for the pkg_state
     #   Use array of openstructs because we need both interest_name and the scripts
     def get_interest_triggers(pkg_state)
-      interest_triggers = []
       check_pkg_state_string(pkg_state)
-      interests = components.flat_map(&:interest_triggers).compact.select { |s| s.pkg_state.include? pkg_state }
-      interests.each do |interest|
-        interest_triggers.push(interest)
-      end
-      interest_triggers.flatten.compact
+      components.flat_map(&:interest_triggers).compact.select { |s| s.pkg_state.include? pkg_state }.flatten.compact
     end
 
     # Collects activate triggers for the project and its components

--- a/lib/vanagon/utilities.rb
+++ b/lib/vanagon/utilities.rb
@@ -162,13 +162,11 @@ class Vanagon
       error = nil
       tries.to_i.times do
         Timeout::timeout(timeout.to_i) do
-          begin
-            yield
-            return true
-          rescue StandardError => e
-            VanagonLogger.error 'An error was encountered evaluating block. Retrying..'
-            error = e
-          end
+          yield
+          return true
+        rescue StandardError => e
+          VanagonLogger.error 'An error was encountered evaluating block. Retrying..'
+          error = e
         end
       end
 
@@ -257,12 +255,13 @@ class Vanagon
     #
     # @param command [String] command to run locally
     # @param return_command_output [Boolean] whether or not command output should be returned
+    # @param log [Boolean] whether or not to log executed command
     # @return [true, String] Returns true if the command was successful or the
     #                        output of the command if return_command_output is true
     # @raise [RuntimeError] If the command fails an exception is raised
-    def local_command(command, return_command_output: false)
+    def local_command(command, return_command_output: false, log: true)
       clean_environment do
-        VanagonLogger.info "Executing '#{command}' locally"
+        VanagonLogger.info "Executing '#{command}' locally" if log
         if return_command_output
           ret = %x(#{command}).chomp
           if $CHILD_STATUS.success?
@@ -278,7 +277,7 @@ class Vanagon
     end
 
     def clean_environment(&block)
-      return Bundler.with_clean_env(&block) if defined?(Bundler)
+      return Bundler.with_unbundled_env(&block) if defined?(Bundler)
       yield
     end
     private :clean_environment

--- a/spec/lib/vanagon/cli_spec.rb
+++ b/spec/lib/vanagon/cli_spec.rb
@@ -1,18 +1,5 @@
 require 'vanagon/cli'
 
-##
-## Ignore the CLI calling 'exit'
-##
-RSpec.configure do |rspec|
-  rspec.around(:example) do |ex|
-    begin
-      ex.run
-    rescue SystemExit => e
-      puts "Got SystemExit: #{e.inspect}. Ignoring"
-    end
-  end
-end
-
 describe Vanagon::CLI do
   describe "options that don't take a value" do
     [:skipcheck, :verbose].each do |flag|
@@ -33,7 +20,8 @@ describe Vanagon::CLI do
   end
 
   describe "options that only allow limited values" do
-    [[:preserve, ["always", "never", "on-failure"]]].each do |option, values|
+    [[:keepwork, ["always", "never", "on-failure", "on-success"]],
+      [:preserve, ["always", "never", "on-failure"]]].each do |option, values|
       values.each do |value|
         it "can create a parser that accepts \"--#{option} #{value}\"" do
           subject = described_class.new
@@ -42,7 +30,7 @@ describe Vanagon::CLI do
         end
       end
     end
-    [[:preserve, ["bad-argument"]]].each do |option, values|
+    [[:keepwork, ["bad-argument"]], [:preserve, ["bad-argument"]]].each do |option, values|
       values.each do |value|
         it "rejects the bad argument \"--#{option} #{value}\"" do
           subject = described_class.new
@@ -53,7 +41,11 @@ describe Vanagon::CLI do
     end
     it "preserve defaults to :on-failure" do
       subject = described_class.new
-      expect(subject.parse([])).to include(:preserve => :'on-failure')
+      expect(subject.parse(%W[build hello project platform])).to include(:preserve => :'on-failure')
+    end
+    it "keepwork defaults to :never" do
+      subject = described_class.new
+      expect(subject.parse(%W[build hello project platform])).to include(:keepwork => :never)
     end
   end
 

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -71,6 +71,7 @@ describe "Vanagon::Component" do
     end
 
     it "attempts to retrieve from a mirror before a canonical URI" do
+      allow(ENV).to receive(:fetch).with('VANAGON_USE_MIRRORS', 'n').and_return('y')
       allow(subject)
         .to receive(:fetch_url)
         .and_return(false)
@@ -86,6 +87,7 @@ describe "Vanagon::Component" do
     end
 
     it "retrieves from a canonical URI if mirrors are unavailable" do
+      allow(ENV).to receive(:fetch).with('VANAGON_USE_MIRRORS', 'n').and_return('y')
       allow(subject)
         .to receive(:fetch_url)
         .and_return(true)
@@ -98,7 +100,6 @@ describe "Vanagon::Component" do
     end
 
     it 'retrieves from a canonical URI if VANAGON_USE_MIRRORS is set to "n"' do
-      allow(ENV).to receive(:[]).with('VANAGON_USE_MIRRORS').and_return('n')
       allow(subject)
         .to receive(:fetch_url)
         .and_return(true)
@@ -110,7 +111,6 @@ describe "Vanagon::Component" do
     end
 
     it 'retrieves from a canonical URI if VANAGON_USE_MIRRORS is set to "false"' do
-      allow(ENV).to receive(:[]).with('VANAGON_USE_MIRRORS').and_return('false')
       allow(subject)
         .to receive(:fetch_url)
         .and_return(true)

--- a/spec/lib/vanagon/driver_spec.rb
+++ b/spec/lib/vanagon/driver_spec.rb
@@ -110,13 +110,14 @@ describe 'Vanagon::Driver' do
       platform = eval_platform('el-7-x86_64', <<-END)
         platform 'el-7-x86_64' do |plat|
           plat.docker_image 'centos7'
+          plat.docker_arch 'linux/amd64'
         end
       END
 
       expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
       info = create_driver(platform, :engine => 'docker').build_host_info
 
-      expect(info).to match({ 'name'   => 'centos7',
+      expect(info).to match({ 'name'   => 'centos7-linux_amd64',
                               'engine' => 'docker' })
     end
 

--- a/spec/lib/vanagon/engine/docker_spec.rb
+++ b/spec/lib/vanagon/engine/docker_spec.rb
@@ -2,6 +2,10 @@ require 'vanagon/engine/docker'
 require 'vanagon/platform'
 
 describe Vanagon::Engine::Docker do
+  before(:each) do
+    allow(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
+  end
+
   let (:platform_with_docker_image) do
     plat = Vanagon::Platform::DSL.new('debian-10-amd64')
     plat.instance_eval(<<~EOF)
@@ -21,12 +25,12 @@ describe Vanagon::Engine::Docker do
     plat._platform
   end
 
-  let(:platform_with_docker_exec) do
+  let(:platform_use_docker_exec_false) do
     plat = Vanagon::Platform::DSL.new('debian-10-amd64')
     plat.instance_eval(<<~EOF)
       platform 'debian-10-amd64' do |plat|
         plat.docker_image 'debian:10-slim'
-        plat.use_docker_exec true
+        plat.use_docker_exec false
       end
     EOF
     plat._platform
@@ -34,6 +38,7 @@ describe Vanagon::Engine::Docker do
 
   describe '#initialize' do
     it 'fails without docker installed' do
+      allow(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_call_original
       ENV['PATH'].split(File::PATH_SEPARATOR).each do |path_elem|
         expect(FileTest).to receive(:executable?).with(File.join(path_elem, 'docker')).and_return(false)
       end
@@ -44,24 +49,21 @@ describe Vanagon::Engine::Docker do
 
   describe "#validate_platform" do
     it 'raises an error if the platform is missing a required attribute' do
-      expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
       expect { described_class.new(platform_without_docker_image).validate_platform }.to raise_error(Vanagon::Error)
     end
 
     it 'returns true if the platform has the required attributes' do
-      expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
       expect(described_class.new(platform_with_docker_image).validate_platform).to be(true)
     end
   end
 
   it 'returns "docker" name' do
-    expect(Vanagon::Utilities).to receive(:find_program_on_path).with('docker').and_return('/usr/bin/docker')
     expect(described_class.new(platform_with_docker_image).name).to eq('docker')
   end
 
   describe '#dispatch' do
-    context 'when platform has use_docker_exec set' do
-      subject { described_class.new(platform_with_docker_exec) }
+    context 'when platform does not set use_docker_exec' do
+      subject { described_class.new(platform_with_docker_image) }
 
       it 'uses docker exec' do
         expect(Vanagon::Utilities).to receive(:remote_ssh_command).never
@@ -70,11 +72,22 @@ describe Vanagon::Engine::Docker do
         subject.dispatch('true', true)
       end
     end
+
+    context 'when platform set use_docker_exec false' do
+      subject { described_class.new(platform_use_docker_exec_false) }
+
+      it 'uses docker exec' do
+        expect(Vanagon::Utilities).to receive(:remote_ssh_command).once
+        expect(subject).to receive(:docker_exec).never
+
+        subject.dispatch('true', true)
+      end
+    end
   end
 
   describe '#ship_workdir' do
-    context 'when platform has use_docker_exec set' do
-      subject { described_class.new(platform_with_docker_exec) }
+    context 'when platform does not set use_docker_exec' do
+      subject { described_class.new(platform_with_docker_image) }
 
       it 'uses docker cp' do
         expect(Vanagon::Utilities).to receive(:rsync_to).never
@@ -83,11 +96,22 @@ describe Vanagon::Engine::Docker do
         subject.ship_workdir('foo/')
       end
     end
+
+    context 'when platform set use_docker_exec false' do
+      subject { described_class.new(platform_use_docker_exec_false) }
+
+      it 'uses docker cp' do
+        expect(Vanagon::Utilities).to receive(:rsync_to).once
+        expect(subject).to receive(:docker_cp_globs_to).never
+
+        subject.ship_workdir('foo/')
+      end
+    end
   end
 
   describe '#retrieve_built_artifact' do
-    context 'when platform has use_docker_exec set' do
-      subject { described_class.new(platform_with_docker_exec) }
+    context 'when platform does not set use_docker_exec' do
+      subject { described_class.new(platform_with_docker_image) }
 
       before(:each) do
         allow(FileUtils).to receive(:mkdir_p)
@@ -100,14 +124,29 @@ describe Vanagon::Engine::Docker do
         subject.retrieve_built_artifact('output/*', false)
       end
     end
+
+    context 'when platform set use_docker_exec false' do
+      subject { described_class.new(platform_use_docker_exec_false) }
+
+      before(:each) do
+        allow(FileUtils).to receive(:mkdir_p)
+      end
+
+      it 'uses docker cp' do
+        expect(Vanagon::Utilities).to receive(:rsync_from).twice
+        expect(subject).to receive(:docker_cp_globs_from).never
+
+        subject.retrieve_built_artifact(['output'], false)
+      end
+    end
   end
 
   describe '#select_target' do
-    context 'when platform has use_docker_exec set' do
-      subject { described_class.new(platform_with_docker_exec) }
+    context 'when platform with only docker image' do
+      subject { described_class.new(platform_with_docker_image) }
 
       it 'starts a new docker instance' do
-        expect(Vanagon::Utilities).to receive(:ex).with("/usr/bin/docker run -d --name debian_10-slim-builder   debian:10-slim")
+        expect(Vanagon::Utilities).to receive(:ex).with("/usr/bin/docker run -d --label vanagon=build --name debian_10-slim-builder   debian:10-slim tail -f /dev/null")
 
         subject.select_target
       end

--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -16,22 +16,22 @@ Gem::Specification.new do |gem|
   gem.authors  = ['Puppet By Perforce']
   gem.email    = 'release@puppet.com'
   gem.homepage = 'http://github.com/puppetlabs/vanagon'
-  gem.required_ruby_version = '>=2.3', '<4'
+  gem.required_ruby_version = '>=2.7', '<4'
 
-  gem.add_runtime_dependency('docopt')
+  gem.add_dependency('docopt')
   # Handle git repos responsibly
   # - MIT licensed: https://rubygems.org/gems/git
-  gem.add_runtime_dependency('git', '~> 1.13.0')
+  gem.add_dependency('git', '~> 1.13.0')
   # Parse scp-style triplets like URIs; used for Git source handling.
   # - MIT licensed: https://rubygems.org/gems/build-uri
-  gem.add_runtime_dependency('build-uri', '~> 1.0')
+  gem.add_dependency('build-uri', '~> 1.0')
   # Handle locking hardware resources
   # - ASL v2 licensed: https://rubygems.org/gems/lock_manager
-  gem.add_runtime_dependency('lock_manager', '>= 0')
+  gem.add_dependency('lock_manager', '>= 0')
   # Utilities for `ship` and `repo` commands
   # - ASL v2 licensed: https://rubygems.org/gems/packaging
-  gem.add_runtime_dependency('packaging')
-  gem.add_runtime_dependency('psych', '>= 4.0')
+  gem.add_dependency('packaging')
+  gem.add_dependency('psych', '>= 4.0')
 
   gem.require_path = 'lib'
   gem.bindir       = 'bin'


### PR DESCRIPTION
One thing that's been stuck in my head a while is the fact that we could have built all the OSP things inside containers on a single beefy host, or maybe just a couple of build hosts, rather than requiring a separate VM for every single platform we wanted to build for and having to create an image ourselves for each one. Since I've had some free time lately 😄 , I've just been messing around on my home Linux desktop to see how hard it would actually be to do this to see if I could contribute it to the community.  Since you said you're looking into this area, figured I'd throw up the changes I've made in my recent journey in case that helps!

This expands on @h0tw1r3 's initial work in ospuppet/vanagon to improve docker container use in vanagon. This does several things on top of Jeff's changes.
* Add docker_arch and docker_registry attributes to specify what registry to pull images from (default to docker.io) and what architecture. Most platforms can run containers of a different architecture under emulation.
* Tear down build container if it already exists so retrying builds is less cumbersome
* Make build_host_name include the architecture so it is easier to run builds in parallel without container name collisions
* Standardize the packages list for currently used platforms. It's gotten rather messy and divergent over the years.
* Uses oraclelinux image for el7. This is because the redhat image is too sparse with what tools are available in its repo. It also uses scl to get a newer version of gcc.
* Uses almalinux instead of redhat for 8 and 9 due to the same reasons as above.
* Updates all platforms currently used for building OSP with docker images.
* Comments out a few puppetlabs-specific things that aren't really needed.
* Uses the SUSE registry for sles images. Note that sles 12 doesn't entirely work right probably.
* A workaround for some weirdness with libc-bin on the Ubuntu 22.04 image